### PR TITLE
Apply Modifiers When No Shape Keys Are Present

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -182,7 +182,7 @@ def keep_shapekeys(self, mode=Mode.ALL):
     """
 
     # Check if the object has shapekeys
-    has_shapekeys = self.obj.data.shape_keys is not None and len(self.obj.data.shape_keys.key_blocks) > 1
+    has_shapekeys = self.obj.data.shape_keys is not None and len(self.obj.data.shape_keys.key_blocks) > 0
 
     if not has_shapekeys:
         # Apply modifiers directly if no shapekeys to preserve

--- a/__init__.py
+++ b/__init__.py
@@ -172,16 +172,6 @@ def common_validation(self):
         self.report({'ERROR'}, "Wrong object type. Please select a MESH object")
         return {'CANCELLED'}
 
-    # check for shapekeys
-    if not self.obj.data.shape_keys:
-        self.report({'ERROR'}, "The selected object doesn't have any shapekeys")
-        return {'CANCELLED'}
-
-    # check for multiple shapekeys
-    if len(self.obj.data.shape_keys.key_blocks) == 1:
-        self.report({'ERROR'}, "The selected object only has a base shapekey")
-        return {'CANCELLED'}
-
 def keep_shapekeys(self, mode=Mode.ALL):
     """
     Function which is used by the blender operators to collapse modifier
@@ -190,6 +180,20 @@ def keep_shapekeys(self, mode=Mode.ALL):
     available blender operators (SUBD, SELECTED, ALL) which collapse only
     subdivision surface, the selected or all modifiers respectively.
     """
+
+    # Check if the object has shapekeys
+    has_shapekeys = self.obj.data.shape_keys is not None and len(self.obj.data.shape_keys.key_blocks) > 1
+
+    if not has_shapekeys:
+        # Apply modifiers directly if no shapekeys to preserve
+        log("Object {} has no shapekeys, applying modifiers directly".format(self.obj.name))
+        if mode == Mode.ALL:
+            apply_modifiers(self.obj)
+        elif mode == Mode.SUBD:
+            apply_subdmod(self.obj)
+        elif mode == Mode.SELECTED:
+            apply_selected_modifiers(self.obj, self.resource_list)
+        return {'FINISHED'}
 
     shapekey_names = [block.name for block in self.obj.data.shape_keys.key_blocks]
 


### PR DESCRIPTION
I apologize for submitting this PR out of the blue. I've been using SKkeeper for a while now and noticed some potential improvements, so I thought I'd contribute back to this fantastic addon.

This PR adds support for applying modifiers to objects that don't have any shapekeys. Currently, I often find myself trying to apply modifiers with SKkeeper, only to receive an error that makes me realize the object doesn't have shapekeys. Being able to use SKkeeper for all modifier applications regardless of shapekey presence would be extremely helpful.

## Changes:
- Modified `common_validation()` to not check for shapekeys existence
- Updated `keep_shapekeys()` function to handle objects without shapekeys
- Maintained backward compatibility with existing functionality

I'll be submitting a second PR shortly that adds multi-object selection support. I've kept them separate to make code review easier.

Please let me know if you find any issues or if any modifications are needed. I understand if you prefer not to incorporate these changes.
Thank you.